### PR TITLE
Stop Rserve with shutdown #25

### DIFF
--- a/RServeCLI2.Test/Rservice.cs
+++ b/RServeCLI2.Test/Rservice.cs
@@ -64,7 +64,7 @@ namespace RserveCLI2.Test
             // ReSharper disable UseObjectOrCollectionInitializer
             _rtermProcess = new Process();
             _rtermProcess.StartInfo.FileName = rExeFilePath;
-            _rtermProcess.StartInfo.Arguments = string.Format( "-e \"library( Rserve ); Rserve( port = {0} , wait = TRUE {1});\"" , Port , args );
+            _rtermProcess.StartInfo.Arguments = string.Format( "--no-site-file --no-init-file --no-save -e \"library( Rserve ); Rserve( port = {0} , wait = TRUE {1});\"" , Port , args );
             _rtermProcess.StartInfo.UseShellExecute = false;
             _rtermProcess.StartInfo.CreateNoWindow = !showWindow;
             _rtermProcess.Start();

--- a/RServeCLI2.Test/Rservice.cs
+++ b/RServeCLI2.Test/Rservice.cs
@@ -58,9 +58,9 @@ namespace RserveCLI2.Test
                 args = string.Format( ", args = '--RS-conf {0}' " , configFile.Replace( @"\" , "/" ) );
             }
 
-            // launch RTerm and tell it load Rserve, tell it wait until RServe has completed.  We want RTerm to stay open because
-            // our only strategy for finding/killing RServe is to search RTerm's child processes.  If wait = FALSE then RTerm completes
-            // but RServe does not die
+            // launch RTerm and tell it load Rserve. 
+            // Keep RTerm open, otherwise the child process will be killed.
+            // We will use CmdShutdown to stop the server
             // ReSharper disable UseObjectOrCollectionInitializer
             _rtermProcess = new Process();
             _rtermProcess.StartInfo.FileName = rExeFilePath;
@@ -106,25 +106,12 @@ namespace RserveCLI2.Test
             {
                 if ( disposing )
                 {
-                    // dispose the connetion to server
+                    // dispose the connection to server
                     if ( RConnection != null )
                     {
+                        // Kill the server
+                        RConnection.Shutdown();
                         RConnection.Dispose();
-                    }
-
-                    // kill the server by searching/killing all of Rterm's child processes
-                    KillAllProcessesSpawnedBy( _rtermProcess );
-                    if ( !_rtermProcess.HasExited )
-                    {
-                        // killing RServe will allow Rterm to complete, but there could be a timing issue where HasExited = FALSE, but then
-                        // the call to Kill() below cannot complete because the process is already dead
-                        try
-                        {
-                            _rtermProcess.Kill();
-                        }
-                        // ReSharper disable EmptyGeneralCatchClause
-                        catch ( Exception ) { }
-                        // ReSharper restore EmptyGeneralCatchClause
                     }
                 }
                 _disposed = true;
@@ -137,31 +124,6 @@ namespace RserveCLI2.Test
 
         private bool _disposed; // to detect redundant calls
         private readonly Process _rtermProcess;
-
-        /// <summary>
-        /// Kills all processes spawned by a parent process
-        /// </summary>
-        /// <remarks>
-        /// See:  http://stackoverflow.com/questions/7189117/find-all-child-processes-of-my-own-net-process-find-out-if-a-given-process-is
-        /// </remarks>
-        /// <param name="parentProcess"></param>
-        private static void KillAllProcessesSpawnedBy( Process parentProcess )
-        {
-
-            // NOTE: Process Ids are reused!
-            var searcher = new ManagementObjectSearcher( "SELECT * FROM Win32_Process WHERE ParentProcessId=" + parentProcess.Id );
-            ManagementObjectCollection collection = searcher.Get();
-            foreach ( var item in collection )
-            {
-                var childProcessId = ( UInt32 )item[ "ProcessId" ];
-                if ( ( int )childProcessId != Process.GetCurrentProcess().Id )
-                {
-                    Process childProcess = Process.GetProcessById( ( int )childProcessId );
-                    KillAllProcessesSpawnedBy( childProcess );
-                    childProcess.Kill();
-                }
-            }
-        }
 
         #endregion
     }

--- a/RServeCLI2/RConnection.cs
+++ b/RServeCLI2/RConnection.cs
@@ -329,6 +329,23 @@ namespace RserveCLI2
             _protocol.Command( CmdCloseFile , new object[] { } );
         }
 
+        /// <summary>
+        /// Attempt to shut down the server process cleanly. 
+        /// </summary>
+        public void Shutdown()
+        {
+           _protocol.Command(CmdShutdown, new object[] { });
+        }
+
+        /// <summary>
+        /// Attempt to shut down the server process cleanly. 
+        /// This command is asynchronous!
+        /// </summary>
+        public void ServerShutdown()
+        {
+           _protocol.Command(CmdCtrlShutdown, new object[] { });
+        }
+
         #endregion
 
         #region Implemented Interfaces

--- a/RServeCLI2/RConnection.cs
+++ b/RServeCLI2/RConnection.cs
@@ -162,7 +162,7 @@ namespace RserveCLI2
             {
                 var ipe = new IPEndPoint( addr , port );
                 var s = new Socket( ipe.AddressFamily , SocketType.Stream , ProtocolType.Tcp );
-                s.Connect( ipe );
+                ConnectAsync( s, ipe );
                 if ( !s.Connected )
                 {
                     continue;
@@ -199,8 +199,28 @@ namespace RserveCLI2
 
             var ipe = new IPEndPoint( addr , port );
             _socket = new Socket( ipe.AddressFamily , SocketType.Stream , ProtocolType.Tcp );
-            _socket.Connect( ipe );
+            ConnectAsync(_socket, ipe );
             Init( user , password );
+        }
+
+        /// Connect with a one-second timeout
+        /// From http://stackoverflow.com/questions/1062035/how-to-config-socket-connect-timeout-in-c-sharp
+        private void ConnectAsync(Socket socket, EndPoint end)
+        {
+           IAsyncResult result = socket.BeginConnect(end, null, null);
+
+           bool success = result.AsyncWaitHandle.WaitOne(1000, true);
+
+           if (success)
+           {
+              socket.EndConnect(result);
+           }
+           else
+           {
+              // NOTE, MUST CLOSE THE SOCKET
+              socket.Close();
+              throw new SocketException((int)SocketError.TimedOut);
+           }
         }
 
         #endregion


### PR DESCRIPTION
This seems to work using CmdShutdown - it passes all the tests except two that give me OutOfMemoryException.

I added RTerm flags `--no-site-file --no-init-file --no-save` because I was having a conflict with my local RProfile.site file (which sets .libPaths). I don't think they will cause trouble and may save others some pain.

The wait=TRUE seems to be needed. Without it, I think RTerm terminates immediately and kills the child Rserve process.

I tried with CmdCtrlShutdown, that did not work.