### PR TITLE
SexpTaggedList.TryGetValue implementation (fixes #38)

### DIFF
--- a/RServeCLI2.Test/RServeCLI2.Test.csproj
+++ b/RServeCLI2.Test/RServeCLI2.Test.csproj
@@ -56,6 +56,7 @@
     <Compile Include="SexpArrayDoubleTest.cs" />
     <Compile Include="SexpArrayIntTest.cs" />
     <Compile Include="SexpListTest.cs" />
+    <Compile Include="SexpTaggedListTest.cs" />
     <Compile Include="SexpTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/RServeCLI2.Test/SexpTaggedListTest.cs
+++ b/RServeCLI2.Test/SexpTaggedListTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Xunit;
+using Xunit.Extensions;
+
+namespace RserveCLI2.Test
+{
+    public class SexpTaggedListTest
+    {
+
+        [Theory]
+        [InlineData("foo", 1   , true)]
+        [InlineData("bar", 2   , true)]
+        [InlineData("baz", 3   , true)]
+        [InlineData("???", null, false)]
+        public void TryGetValue(string key, object value, bool exists)
+        {
+            var list = new SexpTaggedList
+            {
+                new KeyValuePair<string, Sexp>("foo", Sexp.Make(1)),
+                new KeyValuePair<string, Sexp>("bar", Sexp.Make(2)),
+                new KeyValuePair<string, Sexp>("baz", Sexp.Make(3)),
+            };
+
+            Sexp actual;
+            var found = list.TryGetValue(key, out actual);
+            Assert.Equal(exists, found);
+            if (!exists)
+                return;
+            Assert.Equal(Sexp.Make(value), actual, EqualityComparer<Sexp>.Default);
+        }
+    }
+}

--- a/RServeCLI2/SexpTaggedList.cs
+++ b/RServeCLI2/SexpTaggedList.cs
@@ -131,7 +131,7 @@ namespace RserveCLI2
         {
             get
             {
-                int ndx = Value.FindIndex( x => x.Key == key );
+                int ndx = IndexOfKey( key );
                 if ( ndx < 0 )
                 {
                     throw new KeyNotFoundException();
@@ -142,7 +142,7 @@ namespace RserveCLI2
 
             set
             {
-                int ndx = Value.FindIndex( x => x.Key == key );
+                int ndx = IndexOfKey( key );
                 if ( ndx < 0 )
                 {
                     Value.Add( new KeyValuePair<string , Sexp>( key , value ) );
@@ -342,10 +342,22 @@ namespace RserveCLI2
         /// <param name="value">When this method returns, the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value"/> parameter. This parameter is passed uninitialized.</param>
         /// <returns>
         /// true if the object that implements IDictionary contains an element with the specified key; otherwise, false.
-        /// </returns>        
+        /// </returns>
         public override bool TryGetValue( string key , out Sexp value )
         {
-            throw new NotImplementedException();
+            var ndx = IndexOfKey( key );
+            if ( ndx < 0 )
+            {
+                value = null;
+                return false;
+            }
+            value = Value[ ndx ].Value;
+            return true;
+        }
+
+        int IndexOfKey(string key)
+        {
+            return Value.FindIndex( e => e.Key == key );
         }
 
         #endregion


### PR DESCRIPTION
Implements `SexpTaggedList.TryGetValue` and also consolidates duplication of how the key is searched (was being done in 3 places now and that can't be a good thing).