### PR TITLE
FIX BUG: DECODING DATE VECTOR WITH NA VALUE THROWS EXCEPTION

### DIFF
--- a/RServeCLI2.Test/SexpArrayDateTest.cs
+++ b/RServeCLI2.Test/SexpArrayDateTest.cs
@@ -149,7 +149,25 @@ namespace RserveCLI2.Test
                 Assert.Equal( new[] { new DateTime( 2012 , 01 , 01 ) , new DateTime( 1970 , 01 , 01 ) , new DateTime( 1950 , 06 , 08 ) } , sexp2.AsDates );
                 Assert.Equal( new[] { new DateTime( 2012 , 01 , 01 ) , new DateTime( 1970 , 01 , 01 ) , new DateTime( 1950 , 06 , 08 ) } , sexp3.AsDates );
             }
-        }        
+        }
+
+        [Fact]
+        public void AsDates_SexpConstructedFromR_WithNA()
+        {
+            using (var service = new Rservice())
+            {
+                // Arrange & Act
+                Sexp sexpNA1 = service.RConnection["as.Date(c('2012-01-01', NA))"];
+
+                service.RConnection.VoidEval("test = as.Date(c('2012-01-01', NA))");
+                service.RConnection.VoidEval("mode( test ) = 'integer'");
+                Sexp sexpNA2 = service.RConnection["test"];
+
+                // Assert
+                Assert.Equal(new[] { new DateTime(2012, 01, 01), DateTime.MaxValue }, sexpNA1.AsDates);
+                Assert.Equal(new[] { new DateTime(2012, 01, 01), DateTime.MaxValue }, sexpNA2.AsDates);
+            }
+        }
 
         [Fact]
         public void Indexer_Get_ReturnsSexpWithExpectedDate()

--- a/RServeCLI2/Qap1.cs
+++ b/RServeCLI2/Qap1.cs
@@ -801,22 +801,34 @@ namespace RserveCLI2
                     break;
                 case XtArrayDouble:
                     {
-                        var res = new double[ length / 8 ];
-                        var doubleBuf = new byte[ 8 ];
-                        for ( int i = 0 ; i < length ; i += 8 )
+                        var res = new double[length / 8];
+                        var doubleBuf = new byte[8];
+                        for (int i = 0; i < length; i += 8)
                         {
-                            Array.Copy( data , start + i , doubleBuf , 0 , 8 );
-                            res[ i / 8 ] = BitConverter.ToDouble( doubleBuf , 0 );
+                            Array.Copy(data, start + i, doubleBuf, 0, 8);
+                            res[i / 8] = BitConverter.ToDouble(doubleBuf, 0);
                         }
 
                         // is date or just a double?
-                        if ( ( attrs != null ) && ( attrs.ContainsKey( "class" ) && attrs[ "class" ].AsStrings.Contains( "Date" ) ) )
+                        if ((attrs != null) && (attrs.ContainsKey("class") && attrs["class"].AsStrings.Contains("Date")))
                         {
-                            result = new SexpArrayDate( res.Select( Convert.ToInt32 ) );
+                            int[] tempBuf = new int[res.Length];
+                            for (int i = 0; i < res.Length; ++i)
+                            {
+                                if (double.IsNaN(res[i]))
+                                {
+                                    tempBuf[i] = SexpArrayInt.Na;
+                                }
+                                else
+                                {
+                                    tempBuf[i] = Convert.ToInt32(res[i]);
+                                }
+                            }
+                            result = new SexpArrayDate(tempBuf);
                         }
                         else
                         {
-                            result = new SexpArrayDouble( res );
+                            result = new SexpArrayDouble(res);
                         }
                     }
                     break;

--- a/RServeCLI2/SexpArrayDate.cs
+++ b/RServeCLI2/SexpArrayDate.cs
@@ -26,6 +26,11 @@ namespace RserveCLI2
         /// </summary>
         private static readonly DateTime Origin = new DateTime( 1970 , 1 , 1 );
 
+        /// <summary>
+        /// The special values that marks an DateTime as NA.
+        /// </summary>
+        internal new static readonly DateTime NaValue = DateTime.MaxValue;
+
         #endregion
 
         #region Constructors and Destructors
@@ -95,6 +100,17 @@ namespace RserveCLI2
             get
             {
                 return Value.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets a representation of the NA value.
+        /// </summary>
+        public new static DateTime Na
+        {
+            get
+            {
+                return NaValue;
             }
         }
 
@@ -263,9 +279,13 @@ namespace RserveCLI2
         /// <summary>
         /// Converts a DateTime into an R integer
         /// </summary>
-        private static DateTime RIntToDate( int rdate )
+        private static DateTime RIntToDate(int rdate)
         {
-            return Origin.AddDays( rdate );
+            if (rdate == SexpArrayInt.Na)
+            {
+                return SexpArrayDate.Na;
+            }
+            return Origin.AddDays(rdate);
         }
 
         #endregion


### PR DESCRIPTION
* Add a special NA value in SexpArrayDate.cs, which is DateTime.MaxValue
* Correctly catch NaN doubles and convert it to SexpArrayInt.Na in Qap1.cs
* Add a test in SexpArrayDateTest.cs for decoding date vector with NA value(s) #8 